### PR TITLE
Modernizing MQ2AutoSize and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+7/11/2024
+--
+Added
+- MQ Settings panel (/mqsettings -> plugin -> AutoSize)
+- AutoSize TLO (check wiki for details)
+- Introduced Synchronization ability - only available in the UI
+- Enhanced options to accept instruction such as on and off, not just be a toggle. This was done to enable keeping toons in sync by setting values instead of randomly toggling.
+
+Updated / Fixed
+- Zonewide now uses 1000 range
+- /autosize range # now works
+- Reduced organic growth of code and made all toggle options use the ToggleOption function
+- Fixed and altered how "Everything" works. Now it will enable the options, which work as intended.
+
+Deprecated
+- OptZone since it never worked as expected, replaced with Range of 1000 which is about the same as the EQ visible max clipping plane
+- ResizeAll configuration, while Everything is still able to be enabled
+- DefaultSize configuration and command (/autosize size), while Everything is still able to be enabled
+- SizeDefault since having a default setting to resize something to, which wasn't opted in for resizing, doesn't actually make any sense. Outputs have persisted to ensure no script that scrapes the line breaks.
+- SizeTarget (and /autosize target) since it would only resize for one frame if the type was managed by an Option for resizing
+- OptByRange and SizeByRange, since the plugin now only uses range to resize
+
+
+Under the hood
+- Changed the majority of floats to integer as there was no reason for using all the floats
+- Updated pCharSpawn to pLocalPlayer references

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -80,6 +80,175 @@ public:
 };
 COurSizes AS_Config;
 
+// exposed TLO variables
+class MQ2AutoSizeType* pAutoSizeType = 0;
+class MQ2AutoSizeType : public MQ2Type
+{
+public:
+	enum AutoSizeMembers
+	{
+		Active,
+		AutoSave,
+		ResizePC,
+		ResizeNPC,
+		ResizePets,
+		ResizeMercs,
+		ResizeAll,
+		ResizeMounts,
+		ResizeCorpse,
+		ResizeSelf,
+		SizeByRange,
+		Range,
+		SizeDefault,
+		SizePC,
+		SizeNPC,
+		SizePets,
+		SizeMercs,
+		SizeTarget,
+		SizeMounts,
+		SizeCorpse,
+		SizeSelf
+	};
+
+	MQ2AutoSizeType() :MQ2Type("AutoSize")
+	{
+		TypeMember(Active);
+		TypeMember(AutoSave);
+		TypeMember(ResizePC);
+		TypeMember(ResizeNPC);
+		TypeMember(ResizePets);
+		TypeMember(ResizeMercs);
+		TypeMember(ResizeAll);
+		TypeMember(ResizeMounts);
+		TypeMember(ResizeCorpse);
+		TypeMember(ResizeSelf);
+		TypeMember(SizeByRange);
+		TypeMember(Range);
+		TypeMember(SizeDefault);
+		TypeMember(SizePC);
+		TypeMember(SizeNPC);
+		TypeMember(SizePets);
+		TypeMember(SizeMercs);
+		TypeMember(SizeTarget);
+		TypeMember(SizeMounts);
+		TypeMember(SizeCorpse);
+		TypeMember(SizeSelf);
+	}
+
+	~MQ2AutoSizeType()
+	{
+	}
+
+	bool GetMember(MQVarPtr VarPtr, const char* Member, char* Index, MQTypeVar& Dest)
+	{
+
+		MQTypeMember* pMember = MQ2AutoSizeType::FindMember(Member);
+		if (!pMember)
+			return false;
+
+		switch ((AutoSizeMembers)pMember->ID)
+		{
+		case Active:
+			Dest.Int = AS_Config.OptPC || AS_Config.OptNPC || AS_Config.OptPet || AS_Config.OptMerc || AS_Config.OptMount || AS_Config.OptCorpse || AS_Config.OptSelf;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case AutoSave:
+			Dest.Int = AS_Config.OptAutoSave;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizePC:
+			Dest.Int = AS_Config.OptPC;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeNPC:
+			Dest.Int = AS_Config.OptNPC;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizePets:
+			Dest.Int = AS_Config.OptPet;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeMercs:
+			Dest.Int = AS_Config.OptMerc;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeAll:
+			Dest.Int = AS_Config.OptEverything;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeMounts:
+			Dest.Int = AS_Config.OptMount;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeCorpse:
+			Dest.Int = AS_Config.OptCorpse;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case ResizeSelf:
+			Dest.Int = AS_Config.OptSelf;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case SizeByRange:
+			Dest.Int = AS_Config.OptByRange;
+			Dest.Type = datatypes::pBoolType;
+			return true;
+		case Range:
+			Dest.Int = AS_Config.ResizeRange;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeDefault:
+			Dest.Int = AS_Config.SizeDefault;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizePC:
+			Dest.Int = AS_Config.SizePC;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeNPC:
+			Dest.Int = AS_Config.SizeNPC;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizePets:
+			Dest.Int = AS_Config.SizePet;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeMercs:
+			Dest.Int = AS_Config.SizeMerc;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeTarget:
+			Dest.Int = AS_Config.SizeTarget;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeMounts:
+			Dest.Int = AS_Config.SizeMount;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeCorpse:
+			Dest.Int = AS_Config.SizeCorpse;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		case SizeSelf:
+			Dest.Int = AS_Config.SizeSelf;
+			Dest.Type = datatypes::pIntType;
+			return true;
+		}
+		return false;
+	}
+
+	bool ToString(MQVarPtr VarPtr, char* Destination)
+	{
+		return true;
+	}
+};
+
+bool dataAutoSize(const char* szIndex, MQTypeVar& ret)
+{
+	ret.DWord = 1;
+	ret.Type = pAutoSizeType;
+	return true;
+}
+
 // class to access the ChangeHeight function
 class PlayerZoneClient_Hook
 {
@@ -718,7 +887,8 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine)
 PLUGIN_API void InitializePlugin()
 {
 	EzDetour(PlayerZoneClient__ChangeHeight, &PlayerZoneClient_Hook::ChangeHeight_Detour, &PlayerZoneClient_Hook::ChangeHeight_Trampoline);
-
+	pAutoSizeType = new MQ2AutoSizeType;
+	AddMQ2Data("AutoSize", dataAutoSize);
 	AddCommand("/autosize", AutoSizeCmd);
 	AddSettingsPanel("plugins/AutoSize", DrawAutoSize_MQSettingsPanel);
 	LoadINI();
@@ -731,7 +901,8 @@ PLUGIN_API void ShutdownPlugin()
 	RemoveCommand("/autosize");
 	SpawnListResize(true);
 	SaveINI();
-
+	RemoveMQ2Data("AutoSize");
+	delete pAutoSizeType;
 }
 
 void DrawAutoSize_MQSettingsPanel()

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -37,6 +37,7 @@ void DoGroupCommand(std::string_view command, bool includeSelf);
 void ChooseInstructionPlugin();
 void emulate(std::string type);
 void DrawAutoSize_MQSettingsPanel();
+void SendGroupCommand(std::string who);
 int optZonewide = 2; // defaults to selecting Range
 int selectedComms = 0; // defaults to none, OnPulse will query for updates
 int previousRangeDistance = 0;
@@ -585,7 +586,19 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 		return;
 	}
 	else if (ci_equals(szCurArg, "autosave")) {
-		ToggleOption("Autosave", &AS_Config.OptAutoSave);
+		if (ci_equals(szNumber, "on")) {
+			if (!AS_Config.OptAutoSave) {
+				ToggleOption("Autosave", &AS_Config.OptAutoSave);
+			}
+		}
+		else if (ci_equals(szNumber, "off")) {
+			if (AS_Config.OptAutoSave) {
+				ToggleOption("Autosave", &AS_Config.OptAutoSave);
+			}
+		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			ToggleOption("Autosave", &AS_Config.OptAutoSave);
+		}
 		return;
 	}
 	else if (ci_equals(szCurArg, "range")) {
@@ -617,14 +630,34 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 		SetSizeConfig("Self", iNewSize, &AS_Config.SizeSelf);
 	}
 	else if (ci_equals(szCurArg, "pc")) {
-		if (!ToggleOption("PC", &AS_Config.OptPC)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptPC) {
+			ToggleOption("PC", &AS_Config.OptPC);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptPC) {
+			ToggleOption("PC", &AS_Config.OptPC);
 			ResetAllByType(PC);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("PC", &AS_Config.OptPC)) {
+				ResetAllByType(PC);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "npc")) {
-		if (!ToggleOption("NPC", &AS_Config.OptNPC)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptNPC) {
+			ToggleOption("NPC", &AS_Config.OptNPC);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptNPC) {
+			ToggleOption("NPC", &AS_Config.OptNPC);
 			ResetAllByType(NPC);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("PC", &AS_Config.OptNPC)) {
+				ResetAllByType(NPC);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "everything")) {
 		// a different approach for a better user experience
@@ -651,38 +684,84 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 		}		
 	}
 	else if (ci_equals(szCurArg, "pets")) {
-		if (!ToggleOption("Pets", &AS_Config.OptPet)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptPet) {
+			ToggleOption("Pets", &AS_Config.OptPet);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptPet) {
+			ToggleOption("Pets", &AS_Config.OptPet);
 			ResetAllByType(PET);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("Pets", &AS_Config.OptPet)) {
+				ResetAllByType(PET);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "mercs")) {
-		if (!ToggleOption("Mercs", &AS_Config.OptMerc)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptMerc) {
+			ToggleOption("Mercs", &AS_Config.OptMerc);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptMerc) {
+			ToggleOption("Mercs", &AS_Config.OptMerc);
 			ResetAllByType(MERCENARY);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("Mercs", &AS_Config.OptMerc)) {
+				ResetAllByType(MERCENARY);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "mounts")) {
-		if (!ToggleOption("Mounts", &AS_Config.OptMount)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptMount) {
+			ToggleOption("Mounts", &AS_Config.OptMount);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptMount) {
+			ToggleOption("Mounts", &AS_Config.OptMount);
 			ResetAllByType(MOUNT);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("Mounts", &AS_Config.OptMount)) {
+				ResetAllByType(MOUNT);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "corpse")) {
-		if (!ToggleOption("Corpses", &AS_Config.OptCorpse)) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptCorpse) {
+			ToggleOption("Corpses", &AS_Config.OptCorpse);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptCorpse) {
+			ToggleOption("Corpses", &AS_Config.OptCorpse);
 			ResetAllByType(CORPSE);
 		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("Corpses", &AS_Config.OptCorpse)) {
+				ResetAllByType(CORPSE);
+			}
+		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "target")) {
-		// deprecated because when you use this while having features enabled this feature didn't actually work
+		// deprecated because when you use this while having features enabled this feature didn't actually work.
+		// if you don't have anything resizing, why would you want to resize just the target?
 		WriteChatf("\ay%s\aw:: This feature (\ay%s\ax) has been deprecated. Check /mqsetting -> plugins -> AutoSize.", MODULE_NAME, szCurArg);
 	}
 	else if (ci_equals(szCurArg, "self")) {
-		if (!ToggleOption("Self", &AS_Config.OptSelf)) {
-			if (((PSPAWNINFO)pLocalPlayer)->Mount) {
+		if (ci_equals(szNumber, "on") && !AS_Config.OptSelf) {
+			ToggleOption("Self", &AS_Config.OptSelf);
+		}
+		else if (ci_equals(szNumber, "off") && AS_Config.OptSelf) {
+			ToggleOption("Self", &AS_Config.OptSelf);
+			ChangeSize((PSPAWNINFO)pLocalPlayer, ZERO_SIZE);
+		}
+		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
+			if (!ToggleOption("Self", &AS_Config.OptSelf)) {
 				ChangeSize((PSPAWNINFO)pLocalPlayer, ZERO_SIZE);
 			}
-			else {
-				ChangeSize((PSPAWNINFO)pCharSpawn, ZERO_SIZE);
-			}
 		}
+		return;
 	}
 	else if (ci_equals(szCurArg, "help")) {
 		OutputHelp();
@@ -847,7 +926,6 @@ void DrawAutoSize_MQSettingsPanel() {
 				}
 			}
 
-			ImGui::NewLine();
 			ImGui::SeparatorText("Synchronize clients");
 			if (ImGui::RadioButton("None", &selectedComms, static_cast<int>(CommunicationMode::None))) {
 				selectedComms = static_cast<int>(CommunicationMode::None);
@@ -876,27 +954,27 @@ void DrawAutoSize_MQSettingsPanel() {
 			// if dannet
 			if (selectedComms == static_cast<int>(CommunicationMode::DanNet) && loaded_dannet) {
 				if (ImGui::Button("All")) {
-					DoCommandf("a");
+					SendGroupCommand("all");
 				}
 				ImGui::SameLine();
 				if (ImGui::Button("Zone")) {
-					DoCommandf("a");
+					SendGroupCommand("zone");
 				}
 				ImGui::SameLine();
 				if (ImGui::Button("Raid")) {
-					DoCommandf("a");
+					SendGroupCommand("raid");
 				}
 				ImGui::SameLine();
 				if (ImGui::Button("Group")) {
-					DoCommandf("a");
+					SendGroupCommand("group");
 				}
 			} else if (selectedComms == static_cast<int>(CommunicationMode::EQBC) && loaded_eqbc) {
 				if (ImGui::Button("All")) {
-					DoCommandf("a");
+					SendGroupCommand("all");
 				}
 				ImGui::SameLine();
 				if (ImGui::Button("Group")) {
-					DoCommandf("a");
+					SendGroupCommand("group");
 				}
 			}
 
@@ -1003,14 +1081,27 @@ void DrawAutoSize_MQSettingsPanel() {
 	}
 }
 
-void DoGroupCommand(std::string who, std::string_view command) {
-	if (selectedComms == static_cast<int>(CommunicationMode::EQBC)) {
+// send instruction to select few
+// -> dannet: all, zone, raid, group
+// -> eqbc: all, group
+void SendGroupCommand(std::string who) {
+	if (selectedComms == static_cast<int>(CommunicationMode::None)) {
 		WriteChatf("MQ2AutoSize: Cannot execute group command, no group plugin configured.");
 		return;
 	}
 
 	std::string groupCommand;
 	groupCommand = "/squelch ";
+	std::string_view command;
+
+	// if auto save is enabled
+	if (AS_Config.OptAutoSave) {
+		command = "/autosize load";
+	}
+	else {
+		// if auto save is not enabled, save locally then load elsewhere
+		command = "/multiline ; /autosize ";
+	}
 
 	if (selectedComms == static_cast<int>(CommunicationMode::DanNet)) {
 		if (who == "zone")
@@ -1020,7 +1111,7 @@ void DoGroupCommand(std::string who, std::string_view command) {
 		else if (who == "group")
 			groupCommand += fmt::format("/dgga {}", command);
 		else if (who == "all")
-			groupCommand += fmt::format("/dgae all {}", command);
+			groupCommand += fmt::format("/dge {}", command); // everyone but self since we already have it locally
 	}
 	else if (selectedComms == static_cast<int>(CommunicationMode::EQBC)) {
 		if (who == "group")

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -530,7 +530,7 @@ void OutputStatus() {
 		AS_Config.OptMount ? szOn : szOff,
 		AS_Config.OptCorpse ? szOn : szOff,
 		AS_Config.OptSelf ? szOn : szOff,
-		szOff // // no longer available but left to ensure that no random script that reads this, breaks.
+		szOff // no longer available but left to ensure that no random script that reads this, breaks.
 	);
 	WriteChatf("Sizes: PC(\ag%d\ax) NPC(\ag%d\ax) Pets(\ag%d\ax) Mercs(\ag%d\ax) Mounts(\ag%d\ax) Corpses(\ag%d\ax) Target(\ag%d\ax) Self(\ag%d\ax) Everything(\ag%d\ax)",
 		AS_Config.SizePC,

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -1,4 +1,4 @@
-// MQ2AutoSize.cpp : Resize spawns by distance or whole zone (client only)
+// MQ2AutoSize.cpp : Resize spawns by distance (client only)
 
 #include <mq/Plugin.h>
 

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -38,6 +38,8 @@ void emulate(std::string type);
 void DrawAutoSize_MQSettingsPanel();
 void SendGroupCommand(std::string who);
 int RoundToNearestTen(int value);
+static bool isInGroup();
+static bool isInRaid();
 int optZonewide = 2; // defaults to selecting Range
 int selectedComms = 0; // defaults to none, OnPulse will query for updates
 int previousRangeDistance = 0;
@@ -1046,7 +1048,7 @@ void DrawAutoSize_MQSettingsPanel() {
 			}
 			ImGui::EndDisabled();
 
-			// if dannet
+			// dannet
 			if (selectedComms == static_cast<int>(CommunicationMode::DanNet) && loaded_dannet) {
 				if (ImGui::Button("All")) {
 					SendGroupCommand("all");
@@ -1056,21 +1058,28 @@ void DrawAutoSize_MQSettingsPanel() {
 					SendGroupCommand("zone");
 				}
 				ImGui::SameLine();
+				ImGui::BeginDisabled(!isInRaid());
 				if (ImGui::Button("Raid")) {
 					SendGroupCommand("raid");
 				}
+				ImGui::EndDisabled();
 				ImGui::SameLine();
+				ImGui::BeginDisabled(!isInGroup());
 				if (ImGui::Button("Group")) {
 					SendGroupCommand("group");
 				}
+				ImGui::EndDisabled();
 			} else if (selectedComms == static_cast<int>(CommunicationMode::EQBC) && loaded_eqbc) {
+				// eqbc
 				if (ImGui::Button("All")) {
 					SendGroupCommand("all");
 				}
 				ImGui::SameLine();
+				ImGui::BeginDisabled(!isInGroup());
 				if (ImGui::Button("Group")) {
 					SendGroupCommand("group");
 				}
+				ImGui::EndDisabled();
 			}
 
 			ImGui::EndTabItem();
@@ -1258,8 +1267,8 @@ void SendGroupCommand(std::string who) {
 	}
 
 	if (!groupCommand.empty())
-		//DoCommandf(groupCommand.c_str());
-		WriteChatf("DEBUG: command: %s", groupCommand.c_str());
+		DoCommandf(groupCommand.c_str());
+		//WriteChatf("DEBUG: command: %s", groupCommand.c_str());
 }
 
 /**
@@ -1366,4 +1375,22 @@ int RoundToNearestTen(int value) {
 	else {
 		return roundedValue;
 	}
+}
+
+static bool isInGroup() {
+	if (pLocalPC) {
+		if (pLocalPC->Group) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool isInRaid() {
+	if (pRaid) {
+		if (pRaid->RaidMemberCount) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -61,13 +61,12 @@ class COurSizes {
 public:
 	COurSizes() {
 		OptPC = true;
-		OptNPC = OptPet = OptMerc = OptMount = OptCorpse = OptSelf = OptEverything = OptAutoSave = false;
+		OptNPC = OptPet = OptMerc = OptMount = OptCorpse = OptSelf = OptAutoSave = false;
 		ResizeRange = 50;
 		SizeDefault = SizePC = SizeNPC = SizePet = SizeMerc = SizeMount = SizeCorpse = SizeSelf = 1;
 	};
 
 	bool OptAutoSave;
-	bool OptEverything;
 	bool OptPC;
 	bool OptNPC;
 	bool OptPet;
@@ -392,11 +391,6 @@ void SizePasser(PSPAWNINFO pSpawn, bool bReset) {
 		default:
 			break;
 	}
-
-	// no longer used since the Everything feature was changed to work
-	//if (AS_Config.OptEverything && pSpawn->SpawnID != pLPlayer->SpawnID) {
-	//	ChangeSize(pSpawn, bReset ? ZERO_SIZE : AS_Config.SizeDefault);
-	//}
 }
 
 void ResetAllByType(eSpawnType OurType) {
@@ -513,8 +507,8 @@ void OutputStatus() {
 		AS_Config.OptMount ? szOn : szOff,
 		AS_Config.OptCorpse ? szOn : szOff,
 		AS_Config.OptSelf ? szOn : szOff,
-		//AS_Config.OptEverything ? szOn : szOff
-		szOff);
+		szOff // // no longer available but left to ensure that no random script that reads this, breaks.
+	);
 	WriteChatf("Sizes: PC(\ag%d\ax) NPC(\ag%d\ax) Pets(\ag%d\ax) Mercs(\ag%d\ax) Mounts(\ag%d\ax) Corpses(\ag%d\ax) Target(\ag%d\ax) Self(\ag%d\ax) Everything(\ag%d\ax)",
 		AS_Config.SizePC,
 		AS_Config.SizeNPC,
@@ -524,7 +518,8 @@ void OutputStatus() {
 		AS_Config.SizeCorpse,
 		0, // no longer available but left to ensure that no random script that reads this, breaks.
 		AS_Config.SizeSelf,
-		AS_Config.SizeDefault);
+		0 // no longer available but left to ensure that no random script that reads this, breaks.
+	);
 }
 
 bool ToggleOption(const char* pszToggleOutput, bool* pbOption) {

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -862,7 +862,7 @@ void DrawAutoSize_MQSettingsPanel() {
 					emulate("range");
 				}
 				ImGui::TableNextColumn();
-				ImGui::BeginDisabled(AS_Config.ResizeRange == FAR_CLIP_PLANE);
+				ImGui::BeginDisabled(optZonewide == static_cast<int>(ResizeMode::Zonewide));
 				ImGui::PushItemWidth(50.0f);
 				if (ImGui::SliderInt("Range distance (recommended setting)##inputRD", &AS_Config.ResizeRange, 10, 250, "%d", ImGuiSliderFlags_NoInput|ImGuiSliderFlags_AlwaysClamp)) {
 					AS_Config.ResizeRange = RoundToNearestTen(AS_Config.ResizeRange);

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -1239,6 +1239,7 @@ void SendGroupCommand(std::string who) {
 		instruction += fmt::format("/autosize self {}; /autosize sizeself {}; ", AS_Config.OptSelf ? "on" : "off", AS_Config.SizeSelf);
 	}
 
+	// instructions are sent to others, since we have the configuration already
 	if (selectedComms == static_cast<int>(CommunicationMode::DanNet)) {
 		if (who == "zone")
 			groupCommand += fmt::format("/dgze {}", instruction);
@@ -1247,13 +1248,13 @@ void SendGroupCommand(std::string who) {
 		else if (who == "group")
 			groupCommand += fmt::format("/dgge {}", instruction);
 		else if (who == "all")
-			groupCommand += fmt::format("/dge {}", instruction); // everyone but self since we already have it locally
+			groupCommand += fmt::format("/dge {}", instruction);
 	}
 	else if (selectedComms == static_cast<int>(CommunicationMode::EQBC)) {
 		if (who == "group")
-			groupCommand += fmt::format("/bcga /{}", instruction);
+			groupCommand += fmt::format("/bcg /{}", instruction);
 		else if (who == "all")
-			groupCommand += fmt::format("/bcaa /{}", instruction);
+			groupCommand += fmt::format("/bca /{}", instruction);
 	}
 
 	if (!groupCommand.empty())
@@ -1348,7 +1349,7 @@ void emulate(std::string type) {
 }
 
 int RoundToNearestTen(int value) {
-	// Ensure the value is within the accepted range
+	// clamp lower value
 	if (value < 10) {
 		return 10;
 	}
@@ -1356,10 +1357,9 @@ int RoundToNearestTen(int value) {
 		return 250;
 	}
 
-	// Calculate the rounded value
 	int roundedValue = (value + 9) / 10 * 10;
 
-	// Ensure the rounded value is within the accepted range
+	// clamp upper value post rounding
 	if (roundedValue > MAX_SIZE) {
 		return 250;
 	}

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -911,6 +911,136 @@ void DrawAutoSize_MQSettingsPanel()
 	ImGuiTabBarFlags tab_bar_flags = ImGuiTabBarFlags_None;
 	if (ImGui::BeginTabBar("AutoSizeTabBar", tab_bar_flags))
 	{
+				
+		if (ImGui::BeginTabItem("Options"))
+		{
+			ImGui::SeparatorText("General");
+
+			if (ImGui::Checkbox("Enable auto saving of configuration", &AS_Config.OptAutoSave)) {
+				AS_Config.OptAutoSave = !AS_Config.OptAutoSave;
+				DoCommandf("/autosize autosave");
+			}
+			if (ImGui::RadioButton("Zonewide (max clipping plane)", &optZonewide, 0)) {
+				optZonewide = 0; // this is not a boolean, this indicates which radio button to enable
+				previousRangeDistance = AS_Config.ResizeRange;
+				AS_Config.ResizeRange = 1000;
+				AS_Config.OptByRange = true; // TODO: enable by default, comment out any/all zonewide related things
+				SpawnListResize(false);
+			}
+			if (ImGui::BeginTable("OptionsResizeRangeTable", 2, ImGuiTableFlags_RowBg)) {
+				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 20.0f);
+				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
+				ImGui::TableNextColumn();
+				if (ImGui::RadioButton("", &optZonewide, 1)) {
+					optZonewide = 1; // this is not a boolean, this indicates which radio button to enable
+					AS_Config.ResizeRange = previousRangeDistance;
+					AS_Config.OptByRange = true;
+					SpawnListResize(false);
+				}
+				ImGui::TableNextColumn();
+				ImGui::BeginDisabled(AS_Config.ResizeRange == 1000);
+				ImGui::PushItemWidth(50.0f);
+				ImGui::DragInt("Range distance (recommended setting)##inputRD", &AS_Config.ResizeRange, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::EndTable();
+			}
+			ImGui::NewLine();
+			if (ImGui::Button("Display status output")) {
+				DoCommandf("/autosize status");
+			}
+			ImGui::SeparatorText("Toggles");
+			if (ImGui::BeginTable("OptionsResizeSelfTable", 2, ImGuiTableFlags_RowBg)) {
+				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, 20.0f);
+				ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptSelf", &AS_Config.OptSelf)) {
+					AS_Config.OptSelf = !AS_Config.OptSelf;
+					DoCommandf("/autosize self");
+				}
+				ImGui::TableNextColumn();
+				ImGui::SetNextItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptSelf);
+				ImGui::DragInt("Resize: Self##inputSS", &AS_Config.SizeSelf, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptPC", &AS_Config.OptPC)) {
+					AS_Config.OptPC = !AS_Config.OptPC;
+					DoCommandf("/autosize pc");
+				}
+				ImGui::TableNextColumn();
+				ImGui::SetNextItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptPC);
+				ImGui::DragInt("Resize: Other player(s) (incluldes those mounted)##inputOP", &AS_Config.SizePC, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptPet", &AS_Config.OptPet)) {
+					AS_Config.OptPet = !AS_Config.OptPet;
+					DoCommandf("/autosize pets");
+				}
+				ImGui::TableNextColumn();
+				ImGui::PushItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptPet);
+				ImGui::DragInt("Resize: Pets##inputPS", &AS_Config.SizePet, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptMerc", &AS_Config.OptMerc)) {
+					AS_Config.OptMerc = !AS_Config.OptMerc;
+					DoCommandf("/autosize mercs");
+				}
+				ImGui::TableNextColumn();
+				ImGui::PushItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptMerc);
+				ImGui::DragInt("Resize: Mercs##inputMercSize", &AS_Config.SizeMerc, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptMount", &AS_Config.OptMount)) {
+					AS_Config.OptMount = !AS_Config.OptMount;
+					DoCommandf("/autosize mounts");
+				}
+				ImGui::TableNextColumn();
+				ImGui::PushItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptMount);
+				ImGui::DragInt("Resize: Mounts and the Player(s) on them##inputMountSize", &AS_Config.SizeMount, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptCorpse", &AS_Config.OptCorpse)) {
+					AS_Config.OptCorpse = !AS_Config.OptCorpse;
+					DoCommandf("/autosize corpse");
+				}
+				ImGui::TableNextColumn();
+				ImGui::PushItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptCorpse);
+				ImGui::DragInt("Resize: Corpse(s)##inputCS", &AS_Config.SizeCorpse, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				if (ImGui::Checkbox("##OptNPC", &AS_Config.OptNPC)) {
+					AS_Config.OptNPC = !AS_Config.OptNPC;
+					DoCommandf("/autosize npc");
+				}
+				ImGui::TableNextColumn();
+				ImGui::PushItemWidth(50.0f);
+				ImGui::BeginDisabled(!AS_Config.OptNPC);
+				ImGui::DragInt("Resize: NPC(s)##inputNS", &AS_Config.SizeNPC, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
+				ImGui::EndDisabled();
+				ImGui::EndTable();
+			}
+			
+			// display the button if any option is not enabled
+			if (!AS_Config.OptCorpse || !AS_Config.OptMerc || !AS_Config.OptMount || !AS_Config.OptNPC || !AS_Config.OptPC || !AS_Config.OptPet || !AS_Config.OptSelf) {
+				ImGui::NewLine();
+				if (ImGui::Button("Resize Everything")) {
+					DoCommandf("/autosize everything");
+				}
+		}
+			ImGui::EndTabItem();
+		}
+				
 		if (ImGui::BeginTabItem("Commands"))
 		{
 			ImGui::SeparatorText("Toggles");
@@ -947,8 +1077,8 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextRow();
 				ImGui::TableNextColumn(); ImGui::Text("/autosize everything");
 				ImGui::TableNextColumn(); ImGui::Text("Toggles AutoSize all spawn types");
-			ImGui::EndTable();
-			ImGui::Unindent();
+				ImGui::EndTable();
+				ImGui::Unindent();
 			}
 
 			ImGui::SeparatorText("Size configuration (valid: 1 to 250)");
@@ -985,7 +1115,7 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextRow();
 				ImGui::TableNextColumn(); ImGui::Text("/autosize sizeself #");
 				ImGui::TableNextColumn(); ImGui::Text("Sets size for your character");
-			ImGui::EndTable();
+				ImGui::EndTable();
 			}
 			ImGui::Unindent();
 
@@ -1011,107 +1141,10 @@ void DrawAutoSize_MQSettingsPanel()
 				ImGui::TableNextRow();
 				ImGui::TableNextColumn(); ImGui::Text("/autosize autosave");
 				ImGui::TableNextColumn(); ImGui::Text("Automatically save settings to INI file when an option is toggled or size is set");
-			ImGui::EndTable();
+				ImGui::EndTable();
 			}
 			ImGui::Unindent();
 
-		ImGui::EndTabItem();
-		}
-		
-		if (ImGui::BeginTabItem("Options"))
-		{
-			ImGui::SeparatorText("General");
-			if (ImGui::RadioButton("Zonewide (really max clipping plane)", &optZonewide, 0)) {
-				optZonewide = 0; // this is not a boolean, this indicates which radio button to enable
-				previousRangeDistance = AS_Config.ResizeRange;
-				AS_Config.ResizeRange = 1000;
-				AS_Config.OptByRange = true; // TODO: enable by default, comment out any/all zonewide related things
-				SpawnListResize(false);
-			}
-			if (ImGui::RadioButton("Range distance (recommended setting)", &optZonewide, 1)) {
-				optZonewide = 1; // this is not a boolean, this indicates which radio button to enable
-				AS_Config.ResizeRange = previousRangeDistance;
-				AS_Config.OptByRange = true;
-				SpawnListResize(false);
-			}
-			if (ImGui::Checkbox("Enable auto saving of configuration", &AS_Config.OptAutoSave)) {
-				AS_Config.OptAutoSave = !AS_Config.OptAutoSave;
-				DoCommandf("/autosize autosave");
-			}
-			ImGui::NewLine();
-			if (ImGui::Button("Display status output")) {
-				DoCommandf("/autosize status");
-			}
-
-			ImGui::SeparatorText("Toggles");
-			if (ImGui::Checkbox("Resize: Yourself", &AS_Config.OptSelf)) {
-				AS_Config.OptSelf = !AS_Config.OptSelf;
-				DoCommandf("/autosize self");
-			}
-			if (ImGui::Checkbox("Resize: Other players (incluldes those mounted)", &AS_Config.OptPC)) {
-				AS_Config.OptPC = !AS_Config.OptPC;
-				DoCommandf("/autosize pc");
-			}
-			if (ImGui::Checkbox("Resize: Pets", &AS_Config.OptPet)) {
-				AS_Config.OptPet = !AS_Config.OptPet;
-				DoCommandf("/autosize pets");
-			}
-			if (ImGui::Checkbox("Resize: Mercs", &AS_Config.OptMerc)) {
-				AS_Config.OptMerc = !AS_Config.OptMerc;
-				DoCommandf("/autosize mercs");
-			}
-			if (ImGui::Checkbox("Resize: Mounts and the Player(s) on them", &AS_Config.OptMount)) {
-				AS_Config.OptMount = !AS_Config.OptMount;
-				DoCommandf("/autosize mounts");
-			}
-			if (ImGui::Checkbox("Resize: Corpse(s)", &AS_Config.OptCorpse)) {
-				AS_Config.OptCorpse = !AS_Config.OptCorpse;
-				DoCommandf("/autosize corpse");
-			}
-
-			if (ImGui::Checkbox("Resize: NPC(s)", &AS_Config.OptNPC)) {
-				AS_Config.OptNPC = !AS_Config.OptNPC;
-				DoCommandf("/autosize npc");
-			}
-			
-			// display the button if any option is not enabled
-			if (!AS_Config.OptCorpse || !AS_Config.OptMerc || !AS_Config.OptMount || !AS_Config.OptNPC || !AS_Config.OptPC || !AS_Config.OptPet || !AS_Config.OptSelf) {
-				ImGui::NewLine();
-				if (ImGui::Button("Resize Everything")) {
-					DoCommandf("/autosize everything");
-				}
-		}
-			ImGui::EndTabItem();
-		}
-		
-		if (ImGui::BeginTabItem("Settings"))
-		{
-			// included in case code review asks for it to be
-			// provided instead of being a hidden value where
-			// no one is aware of how it works
-			/*
-			ImGui::BeginDisabled(true);
-			ImGui::InputInt("Zonewide##input", &FAR_CLIP_PLANE, 10, 1000);
-			ImGui::EndDisabled();
-			*/
-			ImGui::BeginDisabled(AS_Config.ResizeRange == 1000);
-			ImGui::DragInt("Range distance##inputRD", &AS_Config.ResizeRange, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::EndDisabled();
-			ImGui::DragInt("Self size##inputSS",		&AS_Config.SizeSelf,	1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Other player size##inputSS",&AS_Config.SizePC,		1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Pet size##inputPS",			&AS_Config.SizePet,		1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Merc size##inputMercSize",	&AS_Config.SizeMerc,	1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Mount size##inputMountSize",&AS_Config.SizeMount,	1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Corpse size##inputCS",		&AS_Config.SizeCorpse,	1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("Everything size##inputES",	&AS_Config.SizeDefault, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			ImGui::DragInt("NPC size##inputNS",			&AS_Config.SizeNPC,		1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp);
-			// using SizeTarget will produce a bad experience
-			// while having other options enabled
-			/*
-			if (ImGui::DragInt("Target size##inputTS", &AS_Config.SizeTarget, 1, 1, 250, "%d", ImGuiSliderFlags_AlwaysClamp)) {
-				DoCommandf("/squelch /autosize target");
-			}
-			*/
 			ImGui::EndTabItem();
 		}
 		ImGui::EndTabBar();

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -1268,7 +1268,6 @@ void SendGroupCommand(std::string who) {
 
 	if (!groupCommand.empty())
 		DoCommandf(groupCommand.c_str());
-		//WriteChatf("DEBUG: command: %s", groupCommand.c_str());
 }
 
 /**

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -1204,7 +1204,14 @@ void SendGroupCommand(std::string who) {
 
 	// if auto save is enabled
 	if (AS_Config.OptAutoSave) {
-		instruction = "/autosize load";
+		// check if zonewide is enabled and send instruction
+		if (AS_Config.ResizeRange == FAR_CLIP_PLANE) {
+			instruction += "/multiline ; /autosize load; /autosize on";
+		}
+		else {
+			// just send instruction to load configuration
+			instruction = "/autosize load";
+		}
 	}
 	else {
 		// if auto save is not enabled, we have to go through every setting

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -880,7 +880,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				if (ImGui::SliderInt("Range distance (recommended setting)##inputRD", &AS_Config.ResizeRange, 10, 250, "%d", ImGuiSliderFlags_NoInput|ImGuiSliderFlags_AlwaysClamp)) {
 					AS_Config.ResizeRange = RoundToNearestTen(AS_Config.ResizeRange);
-					SaveINI("ResizeRange", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("ResizeRange", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::EndTable();
@@ -903,7 +905,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::SetNextItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptSelf);
 				if (ImGui::SliderInt("Resize: Self##inputSS", &AS_Config.SizeSelf, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizeSelf", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizeSelf", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -917,7 +921,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::SetNextItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptPC);
 				if (ImGui::SliderInt("Resize: Other player(s) (incluldes those mounted)##inputOP", &AS_Config.SizePC, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizePC", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizePC", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -931,7 +937,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptPet);
 				if (ImGui::SliderInt("Resize: Pets##inputPS", &AS_Config.SizePet, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizePet", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizePet", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -945,7 +953,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptMerc);
 				if (ImGui::SliderInt("Resize: Mercs##inputMercSize", &AS_Config.SizeMerc, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizeMerc", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizeMerc", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -959,7 +969,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptMount);
 				if (ImGui::SliderInt("Resize: Mounts and the Player(s) on them##inputMountSize", &AS_Config.SizeMount, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizeMount", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizeMount", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -973,7 +985,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptCorpse);
 				if (ImGui::SliderInt("Resize: Corpse(s)##inputCS", &AS_Config.SizeCorpse, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizeCorpse", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizeCorpse", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::TableNextRow();
@@ -987,7 +1001,9 @@ void DrawAutoSize_MQSettingsPanel() {
 				ImGui::PushItemWidth(50.0f);
 				ImGui::BeginDisabled(!AS_Config.OptNPC);
 				if (ImGui::SliderInt("Resize: NPC(s)##inputNS", &AS_Config.SizeNPC, 1, 30, "%d", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_AlwaysClamp)) {
-					SaveINI("SizeNPC", true);
+					if (AS_Config.OptAutoSave) {
+						SaveINI("SizeNPC", true);
+					}
 				}
 				ImGui::EndDisabled();
 				ImGui::EndTable();

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -343,7 +343,6 @@ void SaveINI(const std::string& param = "", const bool squelch = 0) {
 	if (!squelch) {
 		WriteChatf("\ay%s\aw:: Configuration file saved.", MODULE_NAME);
 	}
-
 }
 
 void ChangeSize(PlayerClient* pChangeSpawn, float fNewSize) {
@@ -1063,7 +1062,6 @@ void DrawAutoSize_MQSettingsPanel() {
 				}
 				ImGui::EndDisabled();
 			}
-
 			ImGui::EndTabItem();
 		}
 				

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -700,7 +700,7 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 			ResetAllByType(NPC);
 		}
 		else if (!ci_equals(szNumber, "on") && !ci_equals(szNumber, "off")) {
-			if (!ToggleOption("PC", &AS_Config.OptNPC)) {
+			if (!ToggleOption("NPC", &AS_Config.OptNPC)) {
 				ResetAllByType(NPC);
 			}
 		}
@@ -844,7 +844,9 @@ PLUGIN_API void ShutdownPlugin() {
 	RemoveSettingsPanel("plugins/AutoSize");
 	RemoveCommand("/autosize");
 	SpawnListResize(true);
-	SaveINI();
+	if (AS_Config.OptAutoSave) {
+		SaveINI();
+	}
 	RemoveMQ2Data("AutoSize");
 	delete pAutoSizeType;
 }
@@ -1262,7 +1264,8 @@ void SendGroupCommand(std::string who) {
 	}
 
 	if (!groupCommand.empty())
-		DoCommandf(groupCommand.c_str());
+		//DoCommandf(groupCommand.c_str());
+		WriteChatf("DEBUG: command: %s", groupCommand.c_str());
 }
 
 /**

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -1195,55 +1195,48 @@ void SendGroupCommand(std::string who) {
 
 	// if auto save is enabled
 	if (AS_Config.OptAutoSave) {
-		instruction += "/autosize load ";
+		instruction = "/autosize load";
 	}
 	else {
 		// if auto save is not enabled, we have to go through every setting
 		// and create a command which covers both options and size values 
 		// in a single multiline command based on the current settings of
 		// the player instructing the synchronization to happen
-		instruction += "/multiline ; "; // must start with this as there are several instructions
+		instruction = "/multiline ; "; // must start with this as there are several instructions
+		
 		// autosave
-		if (AS_Config.OptAutoSave) {
-			instruction = "/autosize autosave on; ";
-		}
+		instruction += fmt::format("/autosize autosave {}; ", AS_Config.OptAutoSave ? "on" : "off");
+		
 		// zonewide and range
 		if (AS_Config.ResizeRange == FAR_CLIP_PLANE) {
 			// this covers the use case of the instructor having "zonewide" enabled
-			instruction = "/autosize on; ";
+			instruction += "/autosize on; ";
 		}
 		else if (AS_Config.ResizeRange != FAR_CLIP_PLANE) {
 			// this covers the use case of the instructor having "range" enabled
-			instruction = fmt::format("/autosize off; /autosize dist on; /autosize range {}; ", AS_Config.ResizeRange);
+			instruction += fmt::format("/autosize off; /autosize range {}; ", AS_Config.ResizeRange);
 		}
+		
 		// OptPC + SizePC
-		if (AS_Config.OptPC) {
-			instruction = fmt::format("/autosize pc on; /autosize sizepc {}; ", AS_Config.SizePC);
-		}
+		instruction += fmt::format("/autosize pc {}; /autosize sizepc {}; ", AS_Config.OptPC ? "on" : "off", AS_Config.SizePC);
+		
 		// OptNPC + SizeNPC
-		if (AS_Config.OptNPC) {
-			instruction = fmt::format("/autosize npc on; /autosize sizenpc {}; ", AS_Config.SizeNPC);
-		}
-		// OptPet + SizePet
-		if (AS_Config.OptPet) {
-			instruction = fmt::format("/autosize pets on; /autosize sizepets {}; ", AS_Config.SizePet);
-		}
-		// OptMerc + SizeMerc
-		if (AS_Config.OptMerc) {
-			instruction = fmt::format("/autosize mercs on; /autosize sizemercs {}; ", AS_Config.SizeMerc);
-		}
-		// OptMount + SizeMount
-		if (AS_Config.OptMount) {
-			instruction = fmt::format("/autosize mounts on; /autosize sizemounts {}; ", AS_Config.SizeMount);
-		}
-		// OptCorpse + SizeCorpse
-		if (AS_Config.OptCorpse) {
-			instruction = fmt::format("/autosize corpse on; /autosize sizecorpse {}; ", AS_Config.SizeCorpse);
-		}
+		instruction += fmt::format("/autosize npc {}; /autosize sizenpc {}; ", AS_Config.OptNPC ? "on" : "off", AS_Config.SizeNPC);
+				
+		// OptPet + SizePets
+		instruction += fmt::format("/autosize pets {}; /autosize sizepets {}; ", AS_Config.OptPet ? "on" : "off", AS_Config.SizePet);
+
+		// OptMerc + SizeMercs
+		instruction += fmt::format("/autosize mercs {}; /autosize sizemercs {}; ", AS_Config.OptMerc ? "on" : "off", AS_Config.SizeMerc);
+		
+		// OptMount + SizeMounts
+		instruction += fmt::format("/autosize mounts {}; /autosize sizemounts {}; ", AS_Config.OptMount ? "on" : "off", AS_Config.SizeMount);
+		
+		// OptCorpse + SizeCorpses
+		instruction += fmt::format("/autosize corpse {}; /autosize sizecorpse {}; ", AS_Config.OptCorpse ? "on" : "off", AS_Config.SizeCorpse);
+		
 		// OptSelf + SizeSelf
-		if (AS_Config.OptSelf) {
-			instruction = fmt::format("/autosize self on; /autosize sizeself {}; ", AS_Config.SizeSelf);
-		}
+		instruction += fmt::format("/autosize self {}; /autosize sizeself {}; ", AS_Config.OptSelf ? "on" : "off", AS_Config.SizeSelf);
 	}
 
 	if (selectedComms == static_cast<int>(CommunicationMode::DanNet)) {

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -944,10 +944,13 @@ void DrawAutoSize_MQSettingsPanel() {
 			}
 
 			ImGui::SeparatorText("Synchronize clients");
+			ImGui::BeginDisabled(loaded_dannet || loaded_eqbc);
 			if (ImGui::RadioButton("None", &selectedComms, static_cast<int>(CommunicationMode::None))) {
 				selectedComms = static_cast<int>(CommunicationMode::None);
 				return;
 			}
+			ImGui::EndDisabled();
+
 			ImGui::BeginDisabled(!loaded_dannet);
 			if (ImGui::RadioButton("MQ2DanNet", &selectedComms, static_cast<int>(CommunicationMode::DanNet))) {
 				selectedComms = static_cast<int>(CommunicationMode::DanNet);
@@ -1170,11 +1173,11 @@ void SendGroupCommand(std::string who) {
 
 	if (selectedComms == static_cast<int>(CommunicationMode::DanNet)) {
 		if (who == "zone")
-			groupCommand += fmt::format("/dgza {}", instruction);
+			groupCommand += fmt::format("/dgze {}", instruction);
 		else if (who == "raid")
-			groupCommand += fmt::format("/dgra {}", instruction);
+			groupCommand += fmt::format("/dgre {}", instruction);
 		else if (who == "group")
-			groupCommand += fmt::format("/dgga {}", instruction);
+			groupCommand += fmt::format("/dgge {}", instruction);
 		else if (who == "all")
 			groupCommand += fmt::format("/dge {}", instruction); // everyone but self since we already have it locally
 	}

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -596,12 +596,6 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 			// this means we are pretending to be Zonewide and need to revert to Range based
 			// we will do this by reseting the ResizeRange to what is in INI
 			emulate("range");
-
-			// TODO: DELETE
-			//AS_Config.ResizeRange = FAR_CLIP_PLANE;
-			//if (AS_Config.ResizeRange != FAR_CLIP_PLANE) {
-				//SetSizeConfig("range", previousRangeDistance, &AS_Config.ResizeRange);
-			//}
 		}
 		return;
 	}

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -63,7 +63,7 @@ public:
 		OptPC = true;
 		OptNPC = OptPet = OptMerc = OptMount = OptCorpse = OptSelf = OptAutoSave = false;
 		ResizeRange = 50;
-		SizeDefault = SizePC = SizeNPC = SizePet = SizeMerc = SizeMount = SizeCorpse = SizeSelf = 1;
+		SizePC = SizeNPC = SizePet = SizeMerc = SizeMount = SizeCorpse = SizeSelf = 1;
 	};
 
 	bool OptAutoSave;
@@ -76,7 +76,6 @@ public:
 	bool OptSelf;
 
 	int ResizeRange;
-	int SizeDefault;
 	int SizePC;
 	int SizeNPC;
 	int SizePet;
@@ -102,7 +101,6 @@ public:
 		ResizeCorpse,
 		ResizeSelf,
 		Range,
-		SizeDefault,
 		SizePC,
 		SizeNPC,
 		SizePets,
@@ -123,7 +121,6 @@ public:
 		TypeMember(ResizeCorpse);
 		TypeMember(ResizeSelf);
 		TypeMember(Range);
-		TypeMember(SizeDefault);
 		TypeMember(SizePC);
 		TypeMember(SizeNPC);
 		TypeMember(SizePets);
@@ -180,10 +177,6 @@ public:
 				return true;
 			case Range:
 				Dest.Int = AS_Config.ResizeRange;
-				Dest.Type = datatypes::pIntType;
-				return true;
-			case SizeDefault:
-				Dest.Int = AS_Config.SizeDefault;
 				Dest.Type = datatypes::pIntType;
 				return true;
 			case SizePC:
@@ -292,7 +285,6 @@ void LoadINI() {
 	AS_Config.OptCorpse = getOptionValue("Config", "ResizeCorpse", "off");
 	AS_Config.OptSelf = getOptionValue("Config", "ResizeSelf", "off");
 	AS_Config.ResizeRange = getSaneSize("Config", "Range", AS_Config.ResizeRange);
-	AS_Config.SizeDefault = getSaneSize("Config", "SizeDefault", MIN_SIZE);
 	AS_Config.SizePC = getSaneSize("Config", "SizePC", MIN_SIZE);
 	AS_Config.SizeNPC = getSaneSize("Config", "SizeNPC", MIN_SIZE);
 	AS_Config.SizePet = getSaneSize("Config", "SizePets", MIN_SIZE);
@@ -321,7 +313,6 @@ void SaveINI() {
 	if (AS_Config.ResizeRange != FAR_CLIP_PLANE) {
 		WritePrivateProfileString("Config", "Range", std::to_string(AS_Config.ResizeRange), INIFileName);
 	}
-	WritePrivateProfileString("Config", "SizeDefault", std::to_string(AS_Config.SizeDefault), INIFileName);
 	WritePrivateProfileString("Config", "SizePC", std::to_string(AS_Config.SizePC), INIFileName);
 	WritePrivateProfileString("Config", "SizeNPC", std::to_string(AS_Config.SizeNPC), INIFileName);
 	WritePrivateProfileString("Config", "SizePets", std::to_string(AS_Config.SizePet), INIFileName);
@@ -602,8 +593,6 @@ void AutoSizeCmd(PSPAWNINFO pLPlayer, char* szLine) {
 		return;
 	}
 	else if (ci_equals(szCurArg, "size")) {
-		// deprecated because having a default size to be applied to things which are not opt'd to be resized makes no sense.
-		//SetSizeConfig("Default", iNewSize, &AS_Config.SizeDefault);
 		WriteChatf("\ay%s\aw:: This feature (\ay%s\ax) has been deprecated. Check /mqsetting -> plugins -> AutoSize.", MODULE_NAME, szCurArg);
 	}
 	else if (ci_equals(szCurArg, "sizepc")) {

--- a/MQ2AutoSize.cpp
+++ b/MQ2AutoSize.cpp
@@ -322,8 +322,9 @@ void SaveINI(const std::string& param = "", const bool squelch = 0) {
 		if (it != configMap.end()) {
 			WritePrivateProfileString("Config", it->first, it->second, INIFileName);
 		}
-		// special handling for Range key, we don't want to write the FAR_CLIP_PLANE to disk
-		else if (param == "ResizeRange" && AS_Config.ResizeRange != FAR_CLIP_PLANE) {
+		// special handling for Range key, we don't want to write the value to disk unless
+		// it's between MIN_SIZE and MAX_SIZE
+		else if (param == "Range" && AS_Config.ResizeRange >= MIN_SIZE && AS_Config.ResizeRange <= MAX_SIZE) {
 			WritePrivateProfileString("Config", "Range", std::to_string(AS_Config.ResizeRange), INIFileName);
 		}
 	}
@@ -333,7 +334,7 @@ void SaveINI(const std::string& param = "", const bool squelch = 0) {
 			WritePrivateProfileString("Config", key, value, INIFileName);
 		}
 		// special handling for Range since it's not part of the map (intentionally)
-		if (AS_Config.ResizeRange != FAR_CLIP_PLANE) {
+		if (AS_Config.ResizeRange >= MIN_SIZE && AS_Config.ResizeRange <= MAX_SIZE) {
 			WritePrivateProfileString("Config", "Range", std::to_string(AS_Config.ResizeRange), INIFileName);
 		}
 	}
@@ -866,7 +867,7 @@ void DrawAutoSize_MQSettingsPanel() {
 				if (ImGui::SliderInt("Range distance (recommended setting)##inputRD", &AS_Config.ResizeRange, 10, 250, "%d", ImGuiSliderFlags_NoInput|ImGuiSliderFlags_AlwaysClamp)) {
 					AS_Config.ResizeRange = RoundToNearestTen(AS_Config.ResizeRange);
 					if (AS_Config.OptAutoSave) {
-						SaveINI("ResizeRange", true);
+						SaveINI("Range", true);
 					}
 				}
 				ImGui::EndDisabled();

--- a/MQ2AutoSize.rc
+++ b/MQ2AutoSize.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,0
- PRODUCTVERSION 1,0
+ FILEVERSION 1,1
+ PRODUCTVERSION 1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -73,11 +73,11 @@ BEGIN
 #else
             VALUE "FileDescription", "MQ2AutoSize Release Version"
 #endif
-            VALUE "FileVersion", "1.0"
+            VALUE "FileVersion", "1.1"
             VALUE "InternalName", "MQ2AutoSize.dll"
             VALUE "OriginalFilename", "MQ2AutoSize.dll"
             VALUE "ProductName", "MQ2AutoSize"
-            VALUE "ProductVersion", "1.0"
+            VALUE "ProductVersion", "1.1"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
Added
- MQ Settings panel (/mqsettings -> plugin -> AutoSize)
- AutoSize TLO (check wiki for details)
- Introduced Synchronization ability - only available in the UI
- Enhanced options to accept instruction such as on and off, not just be a toggle. This was done to enable keeping toons in sync by setting values instead of randomly toggling.

Updated / Fixed
- Zonewide now uses 1000 range
- /autosize range # now works
- Reduced organic growth of code and made all toggle options use the ToggleOption function
- Fixed and altered how "Everything" works. Now it will enable the options, which work as intended.

Deprecated
- OptZone since it never worked as expected, replaced with Range of 1000 which is about the same as the EQ visible max clipping plane
- ResizeAll configuration, while Everything is still able to be enabled
- DefaultSize configuration and command (/autosize size), while Everything is still able to be enabled
- SizeDefault since having a default setting to resize something to, which wasn't opted in for resizing, doesn't actually make any sense. Outputs have persisted to ensure no script that scrapes the line breaks.
- SizeTarget (and /autosize target) since it would only resize for one frame if the type was managed by an Option for resizing
- OptByRange and SizeByRange, since the plugin now only uses range to resize


Under the hood
- Changed the majority of floats to integer as there was no reason for using all the floats
- Updated pCharSpawn to pLocalPlayer references